### PR TITLE
Exception for scannable type (#74)

### DIFF
--- a/dbscan/example_test.go
+++ b/dbscan/example_test.go
@@ -96,10 +96,13 @@ func ExampleAPI() {
 	}
 
 	// Instantiate a custom API with overridden settings.
-	api := dbscan.NewAPI(
+	api, err := dbscan.NewAPI(
 		dbscan.WithFieldNameMapper(strings.ToLower),
 		dbscan.WithStructTagKey("database"),
 	)
+	if err != nil {
+		// Handle API initialization error.
+	}
 
 	// Query rows from the database that implement Rows interface.
 	// You should also take care of handling rows error after iteration and closing them.

--- a/dbscan/helpers_test.go
+++ b/dbscan/helpers_test.go
@@ -1,9 +1,11 @@
 package dbscan_test
 
 import (
+	"database/sql"
 	"reflect"
 	"testing"
 
+	"github.com/jackc/pgtype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -38,8 +40,14 @@ func queryRows(t *testing.T, query string) dbscan.Rows {
 	return rows
 }
 
-func getAPI() *dbscan.API {
-	return dbscan.NewAPI()
+func getAPI() (*dbscan.API, error) {
+	return dbscan.NewAPI(
+		dbscan.WithScannableTypes(
+			(*sql.Scanner)(nil),
+			(*pgtype.TextDecoder)(nil),
+			(*pgtype.BinaryDecoder)(nil),
+		),
+	)
 }
 
 func scan(t *testing.T, dst interface{}, rows dbscan.Rows) error {

--- a/dbscan/internal_test.go
+++ b/dbscan/internal_test.go
@@ -26,6 +26,7 @@ func DoTestRowScannerStartCalledExactlyOnce(t *testing.T, api *API, queryRows qu
 		rs := args.Get(0).(*RowScanner)
 		rs.columns = []string{"foo", "bar"}
 		rs.columnToFieldIndex = map[string][]int{"foo": {0}, "bar": {1}}
+		rs.scanFn = rs.scanStruct
 	})
 
 	for rows.Next() {

--- a/pgxscan/example_test.go
+++ b/pgxscan/example_test.go
@@ -147,10 +147,17 @@ func ExampleAPI() {
 	}
 
 	// Instantiate a custom API with overridden settings.
-	api := pgxscan.NewAPI(dbscan.NewAPI(
+	dbscanAPI, err := pgxscan.NewDBScanAPI(
 		dbscan.WithFieldNameMapper(strings.ToLower),
 		dbscan.WithStructTagKey("database"),
-	))
+	)
+	if err != nil {
+		// Handle dbscan API initialization error.
+	}
+	api, err := pgxscan.NewAPI(dbscanAPI)
+	if err != nil {
+		// Handle pgxscan API initialization error.
+	}
 
 	db, _ := pgxpool.Connect(ctx, "example-connection-url")
 

--- a/pgxscan/pgxscan_test.go
+++ b/pgxscan/pgxscan_test.go
@@ -15,8 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/georgysavva/scany/dbscan"
-
 	"github.com/georgysavva/scany/pgxscan"
 )
 
@@ -217,8 +215,16 @@ func TestScanRow(t *testing.T) {
 	assert.Equal(t, expected, got)
 }
 
-func getAPI() *pgxscan.API {
-	return pgxscan.NewAPI(dbscan.NewAPI())
+func getAPI() (*pgxscan.API, error) {
+	dbscanAPI, err := pgxscan.NewDBScanAPI()
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	api, err := pgxscan.NewAPI(dbscanAPI)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return api, nil
 }
 
 func TestMain(m *testing.M) {
@@ -234,7 +240,10 @@ func TestMain(m *testing.M) {
 			panic(err)
 		}
 		defer testDB.Close()
-		testAPI = getAPI()
+		testAPI, err = getAPI()
+		if err != nil {
+			panic(err)
+		}
 		return m.Run()
 	}()
 	os.Exit(exitCode)

--- a/sqlscan/example_test.go
+++ b/sqlscan/example_test.go
@@ -145,10 +145,17 @@ func ExampleAPI() {
 	}
 
 	// Instantiate a custom API with overridden settings.
-	api := sqlscan.NewAPI(dbscan.NewAPI(
+	dbscanAPI, err := sqlscan.NewDBScanAPI(
 		dbscan.WithFieldNameMapper(strings.ToLower),
 		dbscan.WithStructTagKey("database"),
-	))
+	)
+	if err != nil {
+		// Handle dbscan API initialization error.
+	}
+	api, err := sqlscan.NewAPI(dbscanAPI)
+	if err != nil {
+		// Handle sqlscan API initialization error.
+	}
 
 	db, _ := sql.Open("postgres", "example-connection-url")
 

--- a/sqlscan/sqlscan.go
+++ b/sqlscan/sqlscan.go
@@ -63,6 +63,18 @@ func ScanRow(dst interface{}, rows *sql.Rows) error {
 	return DefaultAPI.ScanRow(dst, rows)
 }
 
+// NewDBScanAPI creates a new dbscan API object with default configuration settings for sqlscan.
+func NewDBScanAPI(opts ...dbscan.APIOption) (*dbscan.API, error) {
+	defaultOpts := []dbscan.APIOption{
+		dbscan.WithScannableTypes(
+			(*sql.Scanner)(nil),
+		),
+	}
+	opts = append(defaultOpts, opts...)
+	api, err := dbscan.NewAPI(opts...)
+	return api, errors.WithStack(err)
+}
+
 // API is a wrapper around the dbscan.API type.
 // See dbscan.API for details.
 type API struct {
@@ -70,9 +82,9 @@ type API struct {
 }
 
 // NewAPI creates new API instance from dbscan.API instance.
-func NewAPI(dbscanAPI *dbscan.API) *API {
+func NewAPI(dbscanAPI *dbscan.API) (*API, error) {
 	api := &API{dbscanAPI: dbscanAPI}
-	return api
+	return api, nil
 }
 
 // Select is a high-level function that queries rows from Querier and calls the ScanAll function.
@@ -133,5 +145,21 @@ func (api *API) ScanRow(dst interface{}, rows *sql.Rows) error {
 	return errors.WithStack(err)
 }
 
-// DefaultAPI is the default instance of API that is wrapped around the dbscan.DefaultAPI instance.
-var DefaultAPI = NewAPI(dbscan.DefaultAPI)
+func mustNewDBScanAPI(opts ...dbscan.APIOption) *dbscan.API {
+	api, err := NewDBScanAPI(opts...)
+	if err != nil {
+		panic(err)
+	}
+	return api
+}
+
+func mustNewAPI(dbscanAPI *dbscan.API) *API {
+	api, err := NewAPI(dbscanAPI)
+	if err != nil {
+		panic(err)
+	}
+	return api
+}
+
+// DefaultAPI is the default instance of API with all configuration settings set to default.
+var DefaultAPI = mustNewAPI(mustNewDBScanAPI())


### PR DESCRIPTION
This PR adds an exception for scannable types to be treated as primitive types rather than structs or maps.
Fixes: #63, #33, #73.